### PR TITLE
Update babel-preset-minify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "pre-commit": "lint-staged",
   "dependencies": {
     "babel-core": "^6.24.1",
-    "babel-preset-minify": "^0.2.0",
+    "babel-preset-minify": "^0.4.3",
     "webpack-sources": "1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Some great fixes and improvements have made it into babel-preset-minify and neutrino could benefit greatly from them.
